### PR TITLE
Update node-sass to be compatible with node 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.29.0",
     "jest": "^24.1.0",
-    "node-sass": "4.5.3",
+    "node-sass": "4.13",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.8",
     "raf": "3.4.0",
@@ -113,6 +113,7 @@
     "url-loader": "0.6.2",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.9.4",
-    "webpack-manifest-plugin": "1.3.2"
+    "webpack-manifest-plugin": "1.3.2",
+    "yarn": "^1.22.1"
   }
 }


### PR DESCRIPTION
This eliminates the step at: /OpenEats/docs/Running_the_App_Without_Docker.md#install-the-dependecies
It also adds yarn to devDependencies because it is actually required as seen in the following step.