### PR TITLE
Autofocus Grocery list item input on edit

### DIFF
--- a/modules/list/components/ListItem.js
+++ b/modules/list/components/ListItem.js
@@ -80,6 +80,7 @@ export default class ListItem extends React.Component {
         <input
           ref="editField"
           className="edit"
+          autoFocus
           value={ this.state.title }
           onBlur={ this.handleSubmit }
           onChange={ this.handleChange }


### PR DESCRIPTION
When double clicking, sometimes the input box would not be focused
(especially on mobile), and this simply fixes that.

Without the focus, you also couldn't hit Esc or Enter to close the menu, and had to click first.