### PR TITLE
Show print, menu buttons without needing image

### DIFF
--- a/modules/recipe/components/RecipeHeader.js
+++ b/modules/recipe/components/RecipeHeader.js
@@ -35,6 +35,16 @@ const RecipeHeader = ({ photo, title, rating, addToMenu }) => {
           <Ratings stars={ rating }/>
         </div>
       </div>
+      <div className="row options print-hidden">
+        <div className="col-xs-12">
+          <button className="btn btn-primary" onClick={addToMenu}>
+            <span className="glyphicon glyphicon-calendar" aria-hidden="true"/>
+          </button>
+          <button className="btn btn-primary" onClick={ window.print }>
+            <span className="glyphicon glyphicon-print" aria-hidden="true"/>
+          </button>
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This is a quick fix for [the issue](https://github.com/open-eats/OpenEats/issues/111) where the menu and print buttons don't appear on a recipe if that recipe doesn't have an image.  With this change, they show up:

![image](https://user-images.githubusercontent.com/20888380/104541569-7691b900-55e7-11eb-925e-87cd5bb64d30.png)
